### PR TITLE
Make survival::aareg default again, and ignore parameters of ... that…

### DIFF
--- a/R/dpa.R
+++ b/R/dpa.R
@@ -156,6 +156,8 @@ dpa <- function(out.formula, mediator.formulas, id, data, boot.n=100, method = "
   # Bootstrapping is performed by id:
   boot.by=id
 
+  arguments[["id"]] <- "bootstrapID"
+
   for (b in 1:boot.n) {
 
     if(progress_bar) {
@@ -188,7 +190,6 @@ dpa <- function(out.formula, mediator.formulas, id, data, boot.n=100, method = "
     # boot.data[[meta$outcome$stopt]] <- resolve.ties(boot.data[[meta$outcome$stopt]], boot.data[[meta$outcome$event]], obstimes)
 
     arguments[["data"]] <- boot.data
-    arguments[["id"]] <- "bootstrapID"
 
     # Retrieve and summarise coefs under "timereg" implementation
     if (method == "timereg") {

--- a/R/dpa.R
+++ b/R/dpa.R
@@ -158,6 +158,11 @@ dpa <- function(out.formula, mediator.formulas, id, data, boot.n=100, method = "
 
   arguments[["id"]] <- "bootstrapID"
 
+  if (method == "timereg") {
+    # Set/Overwrite n.sim = 0 for all the bootstraps:
+    dot.args[["n.sim"]] <- 0
+  }
+
   for (b in 1:boot.n) {
 
     if(progress_bar) {
@@ -193,9 +198,6 @@ dpa <- function(out.formula, mediator.formulas, id, data, boot.n=100, method = "
 
     # Retrieve and summarise coefs under "timereg" implementation
     if (method == "timereg") {
-
-      # Set/Overwrite n.sim = 0 for all the bootstraps:
-      dot.args[["n.sim"]] <- 0
 
       # Aalen's additive hazard model:
       areg.obj.boot <- base::do.call(Areg, c(arguments, dot.args[base::intersect(formalArgs(timereg::aalen), names(dot.args))]))


### PR DESCRIPTION
… don't belong to the chosen implementation